### PR TITLE
add 'www.' to Instagram-uri

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -685,7 +685,7 @@
       },
       {
          "name" : "Instagram",
-         "check_uri" : "https://instagram.com/{account}/",
+         "check_uri" : "https://www.instagram.com/{account}/",
          "account_existence_code" : "200",
          "account_existence_string" : " Following, ",
          "account_missing_string" : "Page Not Found ",


### PR DESCRIPTION
The reason for this being that Instagram returns status code 301 without it. This causes recon-ng to overlook hits as it sets redirect=False.