### PR TITLE
Added Destructoid.com to json file

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -339,6 +339,17 @@
          "valid" : true
       },
       {
+         "name" : "Destructoid",
+         "check_uri" : "https://www.destructoid.com/?name={account}",
+         "account_existence_code" : "200",
+         "account_existence_string" : "Follow",
+         "account_missing_string" : "Error in query",
+         "account_missing_code" : "200",
+         "known_accounts" : ["john", "alice", "bob"],
+         "category" : "social",
+         "valid" : true
+      },
+      {
          "name" : "DeviantArt",
          "check_uri" : "http://{account}.deviantart.com/",
          "account_existence_code" : "200",


### PR DESCRIPTION
Addition for checking destructoid.com
The website displays an SQL error (lol) when a user is not found, so I set missing code to 200 and missing message to "Error in query" which is a substring of the SQL error message.

Examples: 
Found:
https://www.destructoid.com/?name=alice

Not found:
https://www.destructoid.com/?name=notalice

When testing both names locally, the results were as expected. :)