### PR TITLE
Added Chess.com to json

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -273,6 +273,17 @@
          "valid" : true
       },
       {
+         "name" : "Chess.com",
+         "check_uri" : "https://www.chess.com/member/{account}",
+         "account_existence_code" : "200",
+         "account_existence_string" : "Last Login",
+         "account_missing_string" : "<title>Missing Page?! - Chess.com</title>",
+         "account_missing_code" : "404",
+         "known_accounts" : ["john", "alice", "carol"],
+         "category" : "gaming",
+         "valid" : true
+      },
+      {
          "name" : "Codeacademy",
          "check_uri" : "https://discuss.codecademy.com/u/{account}/summary",
          "account_existence_code" : "200",


### PR DESCRIPTION
Addition for checking chess.com

Examples:
Found:
(inactive)
https://www.chess.com/member/alice
(active)
https://www.chess.com/member/bob
(closed)
https://www.chess.com/member/carol

Not found:
https://www.chess.com/member/doesntexist123456789

When testing all names locally, the results were as expected. The first 3 were found, and the 4th was not found.