### PR TITLE
Bug fix: .items() instead of .iteritems()

### DIFF
--- a/web_accounts_list_checker.py
+++ b/web_accounts_list_checker.py
@@ -123,7 +123,7 @@ def finaloutput():
     if len(overall_results) > 0:
         print('------------')
         print('The following previously "valid" sites had errors:')
-        for site, results in sorted(overall_results.iteritems()):
+        for site, results in sorted(overall_results.items()):
             print(bcolors.YELLOW + '     %s --> %s' % (site, results) + bcolors.ENDC)
     else:
         print(':) No problems with the JSON file were found.')


### PR DESCRIPTION
The execution fails with Python3 (which is both used in the shell script provided and in the `README.md`) with:
```
$ python3.7 ./web_accounts_list_checker.py -s 9gag
 -  Checking 1 sites
[...]
------------
The following previously "valid" sites had errors:
Traceback (most recent call last):
  File "./web_accounts_list_checker.py", line 270, in <module>
    finaloutput()
  File "./web_accounts_list_checker.py", line 126, in finaloutput
    for site, results in sorted(overall_results.iteritems()):
AttributeError: 'dict' object has no attribute 'iteritems'
```

That's because `.iteritems()` is a Python2 thing, in Python3 it's `.items()`. See [Stackoverflow](https://stackoverflow.com/a/30418498/118587)