### PR TITLE
Don't follow redirects

### DIFF
--- a/check_online_presence.py
+++ b/check_online_presence.py
@@ -58,7 +58,7 @@ def signal_handler(*_):
 def web_call(location):
     try:
         # Make web request for that URL, timeout in X secs and don't verify SSL/TLS certs
-        return requests.get(location, headers=HEADERS, timeout=60, verify=False)
+        return requests.get(location, headers=HEADERS, timeout=60, verify=False, allow_redirects=False)
     except requests.exceptions.Timeout as caught:
         raise Exception("Connection time out. Try increasing the timeout delay.") from caught
     except requests.exceptions.TooManyRedirects as caught:

--- a/web_accounts_list_checker.py
+++ b/web_accounts_list_checker.py
@@ -110,7 +110,7 @@ def signal_handler(*_):
 def web_call(location):
     try:
         # Make web request for that URL, timeout in X secs and don't verify SSL/TLS certs
-        resp = requests.get(location, headers=headers, timeout=60, verify=False)
+        resp = requests.get(location, headers=headers, timeout=60, verify=False, allow_redirects=False)
     except requests.exceptions.Timeout:
         return bcolors.RED + '      ! ERROR: CONNECTION TIME OUT. Try increasing the timeout delay.' + bcolors.ENDC
     except requests.exceptions.TooManyRedirects:


### PR DESCRIPTION
Fixes #101. Example site which gets fixed by this is:
anobii
which responds with a redirect on an unknown profile:
```
$ wget "https://www.anobii.com/pIId0vOelhhMSzP6MwXj/profile"
--2020-03-03 19:04:12--  https://www.anobii.com/pIId0vOelhhMSzP6MwXj/profile
Resolving www.anobii.com (www.anobii.com)... 139.59.205.191
Connecting to www.anobii.com (www.anobii.com)|139.59.205.191|:443... connected.
HTTP request sent, awaiting response... 302 Found
```
while the current tool follows the redirect (to a generic address at anobii.com). And after such a redirect it's harder to distinguish between an existing profile and a generic page.