### PR TITLE
Adding Travis - continuous builds of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+
+install:
+  - pip install -r requirements.txt
+  
+script:
+  - python3 check_online_presence.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/WebBreacher/WhatsMyName.svg?branch=master)](https://travis-ci.org/WebBreacher/WhatsMyName)
+
 # WhatsMyName
 This repository has the unified data required to perform user and username enumeration on various websites. Content is in a JSON file and can easily be used in other projects such as the ones below:
 * [Recon-ng](https://bitbucket.org/LaNMaSteR53/recon-ng) - The [Profiler Module](https://bitbucket.org/LaNMaSteR53/recon-ng/src/7723096ce2301092906838ef73564e7907886748/modules/recon/profiles-profiles/profiler.py?at=master&fileviewer=file-view-default) grabs this JSON file and uses it. See https://webbreacher.com/2014/12/11/recon-ng-profiler-module/ for details.


### PR DESCRIPTION
Fixes #2.
Configures Travis CI (open source edition) to build master.

Note:
- the execution currently fails as there are errors with some sites. 
- you can check the results (of my fork) at https://travis-ci.org/mccartney/WhatsMyName

After merging most likely it's required for you @WebBreacher to configure the builds following: https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci (unless you have already done that)