### PR TITLE
Updated diy.org account_missing_string.

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -422,7 +422,7 @@
          "check_uri" : "https://diy.org/{account}",
          "account_existence_code" : "200",
          "account_existence_string" : "Member since",
-         "account_missing_string" : "We couldn't find that page",
+         "account_missing_string" : "We couldn&#x27;t find that!",
          "account_missing_code" : "404",
          "known_accounts" : ["test", "john"],
          "category" : "video",


### PR DESCRIPTION
It seems that this site doesn't support user queries anymore. I tried the known_accounts and some other I found from search engines and none of them succeeded.