### PR TITLE
Add Kaggle

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -1547,7 +1547,7 @@
       },
       {
          "name" : "Kaggle",
-         "check_uri" : "https://www.kaggle.net/{account}",
+         "check_uri" : "https://www.kaggle.com/{account}",
          "account_existence_code" : "200",
          "account_existence_string" : "ProfileContainerReact",
          "account_missing_string" : "NotFound",

--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -1546,6 +1546,17 @@
          "valid" : true
       },
       {
+         "name" : "Kaggle",
+         "check_uri" : "https://www.kaggle.net/{account}",
+         "account_existence_code" : "200",
+         "account_existence_string" : "ProfileContainerReact",
+         "account_missing_string" : "NotFound",
+         "account_missing_code" : "404",
+         "known_accounts" : ["administrator"],
+         "category" : "coding",
+         "valid" : true
+      },
+      {
          "name" : "Keybase",
          "check_uri" : "https://keybase.io/{account}",
          "account_existence_code" : "200",


### PR DESCRIPTION
Add Kaggle. This should work, although the SSL connection died horribly on my test system.

```
$ python3.8 ./web_accounts_list_checker.py -s kaggle -u administrator 
 -  Checking 1 sites
 -  Looking up https://www.kaggle.net/administrator
      ! ERROR: CRITICAL ERROR. HTTPSConnectionPool(host='www.kaggle.net', port=443): Max retries exceeded with url: /administrator (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1124)')))
```
