### PR TITLE
Add Minecraft List

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -1648,13 +1648,13 @@
          "valid" : true
       },
       {
-         "name" : "Minecraft",
-         "check_uri" : "https://namemc.com/name/{account}",
+         "name" : "Minecraft List",
+         "check_uri" : "https://minecraftlist.com/players/{account}",
          "account_existence_code" : "200",
-         "account_existence_string" : "<a href=\"/profile/",
-         "account_missing_string" : "Available*",
+         "account_existence_string" : "Minecraft player profile",
+         "account_missing_string" : "This page could not be found",
          "account_missing_code" : "404",
-         "known_accounts" : ["Alice","Bob"],
+         "known_accounts" : ["popbob","dream"],
          "category" : "gaming",
          "valid" : true
       },
@@ -1756,6 +1756,17 @@
          "account_missing_code" : "404",
          "known_accounts" : ["alice","bob"],
          "category" : "social",
+         "valid" : true
+      },
+      {
+         "name" : "NameMC",
+         "check_uri" : "https://namemc.com/name/{account}",
+         "account_existence_code" : "200",
+         "account_existence_string" : "<a href=\"/profile/",
+         "account_missing_string" : "Available*",
+         "account_missing_code" : "404",
+         "known_accounts" : ["Alice","Bob"],
+         "category" : "gaming",
          "valid" : true
       },
       {


### PR DESCRIPTION
Sometimes Minecraft List can return results which aren't present on NameMC.

Sometimes the website can be a little slow (or maybe it is having temporary issues).

```
$ python3 ./web_accounts_list_checker.py -s namemc -u dream
 -  Checking 1 sites
 >  Looking up https://namemc.com/name/dream

-------------------------------------------
Searching for sites with username (dream) > Found 1 results:

[+] Found user at https://namemc.com/name/dream
$ python3 ./web_accounts_list_checker.py -s namemc -u popbob
 -  Checking 1 sites
 >  Looking up https://namemc.com/name/popbob

-------------------------------------------
Searching for sites with username (popbob) > Found 1 results:

[+] Found user at https://namemc.com/name/popbob
$ python3 ./web_accounts_list_checker.py -s "minecraft list" -u dream
 -  Checking 1 sites
 >  Looking up https://minecraftlist.com/players/dream

-------------------------------------------
Searching for sites with username (dream) > Found 1 results:

[+] Found user at https://minecraftlist.com/players/dream
$ python3 ./web_accounts_list_checker.py -s "minecraft list" -u popbob
 -  Checking 1 sites
 >  Looking up https://minecraftlist.com/players/popbob

-------------------------------------------
Searching for sites with username (popbob) > Found 1 results:

[+] Found user at https://minecraftlist.com/players/popbob
```