### PR TITLE
Removed plug.dj and massRoots from web_accounts_list

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -430,17 +430,6 @@
          "valid" : false
       },
       {
-         "name" : "plug.dj",
-         "check_uri" : "https://plug.dj/@/{account}",
-         "account_existence_code" : "200",
-         "account_existence_string" : "joined",
-         "account_missing_string" : "Where's the party at?",
-         "account_missing_code" : "404",
-         "known_accounts" : ["john", "bob"],
-         "category" : "music",
-         "valid" : true
-      },
-      {
          "name" : "pokemonshowdown",
          "check_uri" : "https://pokemonshowdown.com/users/{account}",
          "account_existence_code" : "200",
@@ -1580,17 +1569,6 @@
          "account_missing_code" : "404",
          "known_accounts" : ["mani-karthik","james-green"],
          "category" : "business",
-         "valid" : true
-      },
-      {
-         "name" : "MassRoots",
-         "check_uri" : "https://api.massroots.com/v1/accounts?singleUser=true&username={account}",
-         "account_existence_code" : "200",
-         "account_existence_string" : "createdAt",
-         "account_missing_string" : "The requested document does not exist",
-         "account_missing_code" : "404",
-         "known_accounts" : ["morgaaan","wes19"],
-         "category" : "health",
          "valid" : true
       },
       {


### PR DESCRIPTION
plug.dj and massroots are no longer exists and the module is crashing when tries to search them.
I have removed both of the site from the web_accounts_list json file until I will have more time to fix the catch phrase so it won't lead to a crash and move the next site if reaching max retries