### PR TITLE
Add support for HTTP headers and fix ProtonMail

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -1954,14 +1954,15 @@
       },
       {
         "name" : "ProtonMail",
-        "check_uri" : "https://api.protonmail.ch/pks/lookup?op=index&search={account}@protonmail.com",
-        "account_existence_code" : "200",
-        "account_existence_string" : "info:1:1",
-        "account_missing_string" : "info:1:0",
+        "check_uri" : "https://account.protonmail.com/api/users/available?Name={account}",
+        "http_headers" : {"x-pm-appversion": "Other"},
+        "account_existence_code" : "409",
+        "account_existence_string" : "\"Code\":12106",
+        "account_missing_string" : "\"Code\":1000",
         "account_missing_code" : "200",
         "known_accounts" : ["admin","test"],
         "category" : "misc",
-        "valid" : false
+        "valid" : true
       },
       {
         "name" : "PSNProfiles",


### PR DESCRIPTION
Adds an optional key (`http_headers`) which can be used to specify additional HTTP headers. This fixes ProtonMail.

Related to issue #293 