### PR TITLE
Removed vizjer.pl from JSON

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -3982,7 +3982,7 @@
       "account_missing_code": "200",
       "known_accounts": ["janek", "tomek"],
       "category": "video",
-      "valid": true
+      "valid": false
     },
     {
       "name": "ulub.pl",


### PR DESCRIPTION
In reference to issue 359 I have disabled vizjer.pl from the JSON as the website has been defaced/taken over by malicious actors.
Virustotal is reporting malware/malicious site, so I think we should be in the safe side here. 