### PR TITLE
New solution for Twitch.tv

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -3956,6 +3956,7 @@
     {
       "name" : "Twitch",
       "check_uri" : "https://twitchtracker.com/search?q={account}",
+      "pretty_uri" : "https://twitch.tv/{account}/",
       "account_existence_code" : "200",
       "account_existence_string" : "Found Exact Match",
       "account_missing_string" : "nothing found",

--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -3954,15 +3954,15 @@
       "valid": true
     },
     {
-      "name" : "Twitch.tv",
-      "check_uri" : "https://passport.twitch.tv/usernames/{account}",
+      "name" : "Twitch",
+      "check_uri" : "https://twitchtracker.com/search?q={account}",
       "account_existence_code" : "200",
-      "account_existence_string" : "",
-      "account_missing_string" : "",
-      "account_missing_code" : "204",
+      "account_existence_string" : "Found Exact Match",
+      "account_missing_string" : "nothing found",
+      "account_missing_code" : "200",
       "known_accounts" : ["summit1g", "cohhcarnage"],
       "category" : "gaming",
-      "valid" : false
+      "valid" : true
       },
       {
         "name" : "fansly",


### PR DESCRIPTION
I've been wanting to switch the URL for Twitch for a while now as the URL we've been using, https://passport.twitch.tv/usernames/USERNAME, is not the prettiest of URLs to link to. The passport site seem also to have had some updates to it which may have broken this specific endpoint as well - time for something new I guess! 

I have added a new URL for our checks, twitchtracker.com, which seem to do the job well. It is used a lot in the Twitch community and is often the go-to site for users when they want stats and general insight into a Twitch account. 