### PR TITLE
Fixed broken site Wikipedia

### DIFF
--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -2432,11 +2432,12 @@
      },
      {
        "name" : "Wikipedia",
-       "check_uri" : "https://en.wikipedia.org/wiki/User:{account}",
+       "check_uri" : "https://en.wikipedia.org/w/api.php?action=query&format=json&list=users&ususers={account}&usprop=cancreate",
+       "pretty_uri" : "https://en.wikipedia.org/wiki/User:{account}",
        "account_existence_code" : "200",
-       "account_existence_string" : "Edit this page",
-       "account_missing_string" : "",
-       "account_missing_code" : "404",
+       "account_existence_string" : "userid",
+       "account_missing_string" : "cancreate",
+       "account_missing_code" : "200",
        "known_accounts" : ["Mcd51", "W._Frank"],
        "category" : "news",
        "valid" : true

--- a/web_accounts_list.json
+++ b/web_accounts_list.json
@@ -2432,11 +2432,11 @@
      },
      {
        "name" : "Wikipedia",
-       "check_uri" : "https://en.wikipedia.org/w/api.php?action=query&format=json&list=users&ususers={account}&usprop=cancreate",
+       "check_uri" : "https://en.wikipedia.org/w/api.php?action=query&format=json&list=users&ususers={account}",
        "pretty_uri" : "https://en.wikipedia.org/wiki/User:{account}",
        "account_existence_code" : "200",
        "account_existence_string" : "userid",
-       "account_missing_string" : "cancreate",
+       "account_missing_string" : "missing:",
        "account_missing_code" : "200",
        "known_accounts" : ["Mcd51", "W._Frank"],
        "category" : "news",


### PR DESCRIPTION
We had an error for for Wikipedia due to, what I assume, is some recent changes on their site. 
Wikipedia is a tough site to check as they have a pretty rigid on-boarding process with numerous username checks. 
This endpoint seems to be our best if not the _only_ option right now. 

Cleaned up the URL even further in my second commit, so that's why there are two. 