### PR TITLE
Small fix for CONTRIBUTING file & add LinkScope to list of projects.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Here is an example of a site element:
          "pretty_uri" : "https://github.com/{account}",
          "account_existence_code" : "200",
          "account_existence_string" : "login:",
-         "account_missing_string" : ["Not Found"],
+         "account_missing_string" : "Not Found",
          "account_missing_code" : "404",
          "known_accounts" : ["test", "webbreacher"],
          "category" : "coding",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository has the unified data required to perform user and username enume
 * [Recon-ng](https://github.com/lanmaster53/recon-ng) - The **Profiler Module** uses this project's JSON content.
 * [sn0int](https://github.com/kpcyrd/sn0int) downloads and uses the JSON file in the [kpcyrd/whatsmyname](https://sn0int.com/r/kpcyrd/whatsmyname) module, see https://twitter.com/sn0int/status/1228046880459907073 for details and instructions.
 * [WMN_screenshooter](https://github.com/swedishmike/WMN_screenshooter) a helper script that is based on `web_accounts_list_checker.py` and uses Selenium to try and grab screenshots of identified profile pages.
+* [LinkScope](https://github.com/AccentuSoft/LinkScope_Client) uses this in the **Whats My Name** resolution under the **Online Identity** category.
 
 ## Content
 


### PR DESCRIPTION
Removed square brackets from "account_missing_string" line in CONTRIBUTING, since it takes a string and not a list of strings.

Added LinkScope to list of projects utilizing this project.

Let us know of any changes needed.