### PR TITLE
limit word wrap length to 50 chars in table output.

### DIFF
--- a/whatsmyname/app/models/schemas/cli.py
+++ b/whatsmyname/app/models/schemas/cli.py
@@ -31,6 +31,7 @@ class CliOptionsSchema(BaseModel):
     capture_error_directory: Optional[str] = None
     validate_knowns: bool = False
     add_error_hints: bool = False
+    word_wrap_length: int = 50
 
 
 

--- a/whatsmyname/app/utilities/formatters.py
+++ b/whatsmyname/app/utilities/formatters.py
@@ -59,6 +59,7 @@ def to_table(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> None:
 
     for site in sites:
         pretty_url = site.uri_pretty.replace("{account}", site.username) if site.uri_pretty else site.generated_uri
+        pretty_url = pretty_url[0:cli_options.word_wrap_length]
         row = [site.name, pretty_url, site.category, site.http_status_code]
         if cli_options.add_error_hints:
             row.append(site.error_hint if site.error_hint else '')


### PR DESCRIPTION
Truncates the pretty uri length in table view of the data.