### PR TITLE
improves debugging and improves the validation check site script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ There are quite a few command line options available:
 
 `python whats_my_name.py -u yooper -c social --format json`
 
-- Check for the user yooper, capture errors for debugging purposes
+- Check for the user yooper, dump out response content and response headers, used for debugging purposes
 
-`python whats_my_name.py -u yooper -c social --capture_errors`
+`python whats_my_name.py -u yooper -s zhihu --verbose --format csv`
+
+- Check for the user whether they exist or not and get the response from the server, used for debugging
+ 
+`python whats_my_name.py -u yooper -a -s zillow --verbose --format csv` 
 
 # Installation
 Check the [INSTALLATION.md file](https://github.com/WebBreacher/WhatsMyName/blob/main/INSTALLATION.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "what-is-my-name"
-version = "0.0.5"
+version = "0.1.0"
 authors = [
   { name="Micah Hoffman", email="micah@spotlight-infosec.com" },
   { name="Dan Cardin", email="dcardin2007@gmail.com" },

--- a/whatsmyname/app/cli/args.py
+++ b/whatsmyname/app/cli/args.py
@@ -42,7 +42,6 @@ def get_default_args() -> ArgumentParser:
     parser.add_argument('-c', '--category', nargs='?', help='[OPTIONAL] Filter by site category ', default=None)
     parser.add_argument('-rv', '--random_validate', action="store_true", help='[OPTIONAL] Upon success, validate using random username', default=False)
     parser.add_argument('-uap', '--user_agent_platform', nargs='?', help='[OPTIONAL] Select the user agent platform to use. ', default='Chrome on Windows 1')
-    parser.add_argument('-ce', '--capture_errors', action="store_true", help='[OPTIONAL] Capture errors per site for a user name', default=False)
     return parser
 
 

--- a/whatsmyname/app/models/schemas/sites.py
+++ b/whatsmyname/app/models/schemas/sites.py
@@ -1,7 +1,9 @@
 """Site Schemas"""
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
+
+from multidict import CIMultiDictProxy
 from pydantic import BaseModel, root_validator
 
 
@@ -14,6 +16,7 @@ class SiteOutputSchema(BaseModel):
     user_agent: str
     uri_pretty: Optional[str] = None
     error_hint: Optional[str] = None
+    response_headers: Optional[str] = None
 
 
 class SiteSchema(BaseModel):
@@ -38,6 +41,7 @@ class SiteSchema(BaseModel):
     user_agent: Optional[str] = None
     uri_pretty: Optional[str] = None
     error_hint: Optional[str] = None
+    response_headers: Optional[str] = None
 
 
     @root_validator

--- a/whatsmyname/app/tasks/process.py
+++ b/whatsmyname/app/tasks/process.py
@@ -4,9 +4,11 @@ import os
 import tempfile
 from asyncio import gather, ensure_future
 from typing import List, Dict
+import json
 
 import aiohttp
 from aiohttp import ClientSession, ClientConnectionError, TCPConnector, ClientTimeout
+from multidict import CIMultiDictProxy
 
 from whatsmyname.app.extractors.file_extractors import site_file_extractor
 from whatsmyname.app.models.schemas.cli import CliOptionsSchema
@@ -133,30 +135,6 @@ def filter_list_by(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> Li
     return list(filter(lambda site: site.http_status_code == site.e_code and site.e_string in site.raw_response_data, filtered_sites))
 
 
-def capture_errors(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> None:
-    """Export not found results to a captured error file. """
-
-    cli_options.capture_error_directory = tempfile.gettempdir()
-
-    # clone the options
-    cloned_cli_options: CliOptionsSchema = CliOptionsSchema(**{**cli_options.dict(), **dict(random_username=None)})
-    cloned_cli_options.not_found = True
-    cloned_cli_options.verbose = True
-
-    not_found_sites = filter_list_by(cloned_cli_options, sites)
-    for site in not_found_sites:
-        username_dir: str = os.path.join(cli_options.capture_error_directory, 'whatsmyname', site.username)
-        if not os.path.exists(username_dir):
-            os.makedirs(username_dir)
-        cloned_cli_options.output_file = os.path.join(username_dir, f'{site.name}.json')
-        if os.path.exists(cloned_cli_options.output_file):
-            logger.info('Removing stall capture error file %s', cloned_cli_options.output_file)
-            os.remove(cloned_cli_options.output_file)
-        logger.info('Writing capture error file %s', cloned_cli_options.output_file)
-        print('Writing capture error file ', cloned_cli_options.output_file)
-        to_json(cloned_cli_options, [site])
-
-
 async def request_controller(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> List[SiteSchema]:
     """Initiates all the web requests"""
     connector: TCPConnector = aiohttp.TCPConnector(ssl=False)
@@ -190,6 +168,7 @@ async def request_worker(session: ClientSession, cli_options: CliOptionsSchema, 
                                ) as response:
             site.http_status_code = response.status
             site.raw_response_data = await response.text()
+            site.response_headers = json.dumps({str(key): value for key, value in response.headers.items()})
             return site
 
     except ClientConnectionError as cce:

--- a/whatsmyname/app/utilities/formatters.py
+++ b/whatsmyname/app/utilities/formatters.py
@@ -13,6 +13,7 @@ def to_csv(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> None:
     if cli_options.verbose:
         field_names.append('raw_response_data')
         field_names.append('user_agent')
+        field_names.append('response_headers')
 
     if cli_options.add_error_hints:
         field_names.append('error_hint')
@@ -31,9 +32,10 @@ def to_json(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> None:
     if cli_options.verbose:
         field_names['raw_response_data'] = True
         field_names['user_agent'] = True
+        field_names['response_headers'] = True
+
     if cli_options.add_error_hints:
         field_names['error_hint'] = True
-
 
     with open(fix_file_name(cli_options.output_file), "w") as fp:
         fp.write("[")


### PR DESCRIPTION
This pull request corrects the validation script to run correctly. It will report back sites that are having issues and provide insight into why are not working.

```sh
python validate_whats_my_name.py
```

If you only want to validate a single site use,
```sh
python validate_whats_my_name.py -s Zomato
```

If you need more information on a site and why it is failing, use the following command
```sh
python whats_my_name.py -u yooper -a -s zillow --verbose --format csv
```
This will return the response body and response headers from a site, regardless if the user was found or not. 

Capture error feature was removed because it can readily be performed by piping the code into a file
```
python whats_my_name.py -u yooper -a -s zillow --verbose --format csv > captured_response.csv
```

