### PR TITLE
Fix Gettr for real

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -2186,10 +2186,11 @@
        {
         "name" : "Gettr",
         "uri_check" : "https://api.gettr.com/s/user/{account}/exist",
+        "uri_pretty" : "https://gettr.com/user/{account}",
         "post_body" : "",
         "e_code" : 200,
-        "e_string" : "claimable\":false",
-        "m_string" : "claimable\":true",
+        "e_string" : "success\":{",
+        "m_string" : "success\":false",
         "m_code" : 200,
         "known" : ["gettr", "support"],
         "cat" : "social",


### PR DESCRIPTION
I thought that I had confirmed that the "claimable" field worked to detect account presence, but it seems not. Random usernames also return claimable as false.

Change the e_string and m_string back to looking at the "success" element. If the username exists, the "success" name will be followed by an object starting with "{" containing user information. If the username does not exist, we will simply see that the value for the "success" name has a value of false.

Add a pretty_uri while we're here.