### PR TITLE
Update wmn-data.json

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -6201,6 +6201,18 @@
         "valid" : true
        },
        {
+        "name" : "WeTransfer",
+        "uri_check" : "https://{account}.wetransfer.com",
+        "post_body" : "",
+        "e_code" : 200,
+        "e_string" : "default_recipient_email",
+        "m_string" : "",
+        "m_code" : 302,
+        "known" : ["mark", "joe"],
+        "cat" : "misc",
+        "valid" : true
+       },
+       {
         "name" : "Wikidot",
         "uri_check" : "http://www.wikidot.com/user:info/{account}",
         "post_body" : "",


### PR DESCRIPTION
WeTransfer has the possibility to host users subdomains, e.g. joe.wetransfer.com. When hitting a valid one WeTransfer returns a 200. The response includes the email of the user the account belongs to in a JS-variable called __session__, which is JSON with the key "default_recipient_email". You can test this with `curl -s 'https://joe.wetransfer.com/' | grep default_recipient_email`. An invalid user yields a status code of 302 and a redirect to wetransfer.com.