### PR TITLE
fix(sec): upgrade poetry-core to 1.1.0a7

### DIFF
--- a/whatsmyname/requirements.txt
+++ b/whatsmyname/requirements.txt
@@ -36,7 +36,7 @@ pkginfo==1.8.3
 platformdirs==2.5.2
 pluggy==1.0.0
 poetry==1.1.14
-poetry-core==1.0.8
+poetry-core==1.1.0a7
 ptyprocess==0.7.0
 py==1.11.0
 pycparser==2.21


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in poetry-core 1.0.8
- [CVE-2022-36069](https://www.oscs1024.com/hd/CVE-2022-36069)


### What did I do？
Upgrade poetry-core from 1.0.8 to 1.1.0a7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS