### PR TITLE
Fix TikTok detection. Use oembed API instead of main site

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -6405,6 +6405,19 @@
         "valid" : true
        },
        {
+        "name" : "TikTok",
+        "uri_check" : "https://www.tiktok.com/oembed?url=https://www.tiktok.com/@{account}",
+        "uri_pretty" : "https://www.tiktok.com/@{account}?lang=en",
+        "post_body" : "",
+        "e_code" : 200,
+        "e_string" : "author_url",
+        "m_string" : "Something went wrong",
+        "m_code" : 400,
+        "known" : ["gordonramsayofficial", "pookiebear73"],
+        "cat" : "social",
+        "valid" : true
+       },
+       {
         "name" : "Tilde.zone (Mastodon Instance)",
         "uri_check" : "https://tilde.zone/api/v1/accounts/lookup?acct={account}",
         "uri_pretty" : "https://tilde.zone/@{account}",


### PR DESCRIPTION
I had problems with tiktok detection. Sometimes there were timeouts (it depends on User Agent), in other times there were almost empty page with javascript. Looks like everything is dynamically loaded now.

After some research I found open API, that doesn't require tokens. It's used for embedding profiles. as I understood. Not sure how it's stable, and how long it will work, but it works well for detection.