### PR TITLE
Update Bentbox e_string match

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -656,7 +656,7 @@
         "uri_check" : "https://bentbox.co/{account}",
         "post_body" : "",
         "e_code" : 200,
-        "e_string" : "BentBox photos and videos",
+        "e_string" : "<div id=\"user_bar\">",
         "m_string" : "This user is currently not available",
         "m_code" : 200,
         "known" : ["brockdoom", "witchhouse", "hotoptics"],


### PR DESCRIPTION
Unfortunately Bentbox returns a 200 status code for both existing and missing users. The existing `e_string` match was present in both instances.

Several lines were changed as GitHub editor normalised line endings to CRLF.
