### PR TITLE
Fix implicit encoding that breaks cross platform usage

### DIFF
--- a/whatsmyname/app/extractors/file_extractors.py
+++ b/whatsmyname/app/extractors/file_extractors.py
@@ -13,7 +13,7 @@ def site_file_extractor(file_path: str) -> List[SiteSchema]:
     :param file_path: str
     :return: List[Site]
     """
-    with open(file_path) as json_file:
+    with open(file_path, "r", encoding="utf-8") as json_file:
         json_data = json.load(json_file)
         sites_configuration = SitesConfigurationSchema(**json_data)
         return sites_configuration.sites
@@ -25,6 +25,6 @@ def user_agent_extractor(file_path: str) -> List[UserAgentSchema]:
     :param file_path: str
     :return: List[UserAgent]
     """
-    with open(file_path) as json_file:
+    with open(file_path, "r", encoding="utf-8") as json_file:
         json_data = json.load(json_file)
         return parse_obj_as(List[UserAgentSchema], json_data)

--- a/whatsmyname/app/utilities/formatters.py
+++ b/whatsmyname/app/utilities/formatters.py
@@ -18,7 +18,7 @@ def to_csv(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> None:
     if cli_options.add_error_hints:
         field_names.append('error_hint')
 
-    with open(cli_options.output_file, "w") as fp:
+    with open(cli_options.output_file, "w", encoding="utf-8") as fp:
         writer = csv.DictWriter(fp, fieldnames=field_names)
         writer.writeheader()
         site: SiteSchema
@@ -37,7 +37,7 @@ def to_json(cli_options: CliOptionsSchema, sites: List[SiteSchema]) -> None:
     if cli_options.add_error_hints:
         field_names['error_hint'] = True
 
-    with open(fix_file_name(cli_options.output_file), "w") as fp:
+    with open(fix_file_name(cli_options.output_file), "w", encoding="utf-8") as fp:
         fp.write("[")
         site: SiteSchema
         for idx, site in enumerate(sites):

--- a/whatsmyname/main.py
+++ b/whatsmyname/main.py
@@ -35,7 +35,7 @@ async def start_check_for_presence(provided_args=None):
         to_table(cli_options, sites)
 
     if cli_options.output_stdout:
-        with open(cli_options.output_file, 'r') as fp:
+        with open(cli_options.output_file, 'r', encoding='utf-8') as fp:
             lines: List[str] = fp.readlines()
             for line in lines:
                 print('{}'.format(line.strip()))
@@ -102,7 +102,7 @@ async def start_validate_whats_my_name() -> None:
         to_table(cli_options, sites)
 
     if cli_options.output_stdout:
-        with open(cli_options.output_file, 'r') as fp:
+        with open(cli_options.output_file, 'r', encoding='utf-8') as fp:
             lines: List[str] = fp.readlines()
             for line in lines:
                 print('{}'.format(line.strip()))


### PR DESCRIPTION
The current code does not specify the encoding when opening files to read/write. Besides breaking one of the Zen of Python-rules (_explicit is better than implicit_) this breaks cross platform as the encoding then is platform dependent (whatever `locale.getencoding()` returns). If this is `cp1252` - which is often the case on Windows - the script crashes. After fixing it on the loading of `wmn-data.json` (https://github.com/WebBreacher/WhatsMyName/blob/7e6ac66d0515e091782f02b3488f1fdbfc316ae9/whatsmyname/app/extractors/file_extractors.py#L16) is actually crashes silently, leading the user to believe that the script does not return any hits. This pull request should fix the issue in every needed part of the library.