### PR TITLE
sukebei.nyaa.si - changed category to XXXPORNXXX since it looks like mainly pr0n torrents

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -5683,7 +5683,7 @@
         "m_code" : 404,
         "m_string" : "404 Not Found",
         "known" : ["kouhy76", "Rektr0"],
-        "cat" : "video",
+        "cat" : "XXXPORNXXX",
         "valid" : true
        },
        {


### PR DESCRIPTION
This site looks like a torrent site for (mainly?) Asian pr0n. 

Having it listed as 'video' might cause some blushes, or worse, if it's displayed/viewed in a stricter environment.

I don't know what the policy on this is - so if you don't agree with the re-categorisation @WebBreacher, just kill the PR.