### PR TITLE
A bit of a grab bag of changes, majority 'just' updates of known user names.

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1131,7 +1131,7 @@
         "e_string" : "<title>  Profile - ",
         "m_string" : "Oops! That page doesn’t exist",
         "m_code" : 404,
-        "known" : ["doctypeme", "jon_morris"],
+        "known" : ["doctypeme", "ocean.war"],
         "cat" : "coding",
         "valid" : true
        },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -849,7 +849,7 @@
         "name" : "cafecito",
         "uri_check" : "https://cafecito.app/{account}",
         "e_code" : 200,
-        "e_string" : " | Cafecito</title>",
+        "e_string" : " | Cafecito</title>",
         "m_string" : "Es posible que el enlace que seleccionaste esté roto o que se haya eliminado la página",
         "m_code" : 404,
         "known" : ["braftty", "guillermo"],

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1375,7 +1375,7 @@
         "e_string" : "About me",
         "m_string" : "The page you are looking for does not exist",
         "m_code" : 404,
-        "known" : ["Lars01", "janeferater"],
+        "known" : ["shime", "janeferater"],
         "cat" : "dating",
         "valid" : true
        },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1081,17 +1081,6 @@
         "valid" : true
        },
        {
-        "name" : "Cloudflare",
-        "uri_check" : "https://community.cloudflare.com/u/{account}",
-        "e_code" : 200,
-        "e_string" : "- Cloudflare Community",
-        "m_string" : "Oops! That page doesn’t exist or is private.",
-        "m_code" : 404,
-        "known" : ["bob", "john"],
-        "cat" : "tech",
-        "valid" : true
-       },
-       {
         "name" : "Clubhouse",
         "uri_check" : "https://www.clubhouse.com/@{account}",
         "e_code" : 200,

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1235,17 +1235,6 @@
         "valid" : true
        },
        {
-        "name" : "Mastodon-counter.social",
-        "uri_check" : "https://counter.social/@{account}",
-        "e_code" : 200,
-        "e_string" : "@counter.social) - CounterSocial</title>",
-        "m_string" : "The page you are looking for isn&#39;t here.",
-        "m_code" : 404,
-        "known" : ["ericconrad", "webbreacher"],
-        "cat" : "social",
-        "valid" : true
-       },
-       {
         "name" : "cowboys4angels",
         "uri_check" : "https://cowboys4angels.com/cowboy/{account}/",
         "e_code" : 200,

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -874,7 +874,7 @@
         "e_string" : "aggregateRating",
         "m_string" : "",
         "m_code" : 301,
-        "known" : ["ryansandes", "sarahall3"],
+        "known" : ["michael_owen10", "sarahall3"],
         "cat" : "shopping",
         "valid" : true
        },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1095,7 +1095,7 @@
         "name" : "Clubhouse",
         "uri_check" : "https://www.clubhouse.com/@{account}",
         "e_code" : 200,
-        "e_string" : ">followers</div>",
+        "e_string" : "- Clubhouse</title>",
         "m_string" : "t find what you were looking for",
         "m_code" : 404,
         "known" : ["kirbyplessas", "rohan"],

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1833,7 +1833,7 @@
         "e_string" : "View Profile",
         "m_string" : "The user you tried to view doesn't seem to be on the site any more",
         "m_code" : 200,
-        "known" : ["naughty_nymphomaniac", "hellfireclub", "fabswingers.com"],
+        "known" : ["justusboth2013", "hellfireclub", "fabswingers.com"],
         "cat" : "dating",
         "valid" : true
        },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -741,7 +741,7 @@
         "e_string" : "Chat público ao vivo de",
         "m_string" : "Câmaras de sexo free: chat pornô ao vivo",
         "m_code" : 404,
-        "known" : ["PrettyKatea", "milaowens"],
+        "known" : ["prettykatea", "milaowens"],
         "cat" : "XXXPORNXXX",
         "valid" : true
        },


### PR DESCRIPTION
There are a few updated known usernames here, tested and verified so should be ok.

Then there is the following:

- `Cafecito` - didn't work, verified by testing via whatsmyname.app too, there was what looked like a control character in the code when viewed in an editor. Removed that and replaced with a 'clean' space and it worked again.
- `Clubhouse` - didn't work, verified by testing via whatsmyname.app too. Had to replace the e_string and now it works again.
- `Mastodon-counter.social` - as discussed yesterday; behind CloudFlare and redirect now so removed. Verified via whatsmyname.app that it doesn't work there any longer too.
- `CloudFlare` - 403's, might even be behind 'itself' so to speak. Removed. Verified via whatsmyname.app that it doesn't work there any longer too.

If/when you ok the removals and merge I'll add those two to the 'removed sites wiki' too.