### PR TITLE
#748 change array to object

### DIFF
--- a/wmn-data-schema.json
+++ b/wmn-data-schema.json
@@ -197,7 +197,7 @@
 					"headers": {
 						"$id": "#root/sites/items/headers",
 						"title": "Headers",
-						"type": "array",
+						"type": "object",
 						"default": [],
 						"items":{
 							"$id": "#root/sites/items/headers/items",


### PR DESCRIPTION
As @janbinx suggested the proper format for the `headers` parameter is an `object` not `array` as I had made it. Fixing it.