### PR TITLE
Internet Archive User Search fix

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -2715,10 +2715,11 @@
        },
        {
         "name" : "Internet Archive User Search",
-        "uri_check" : "https://archive.org/search.php?query={account}",
+        "uri_check" : "https://archive.org/advancedsearch.php?q={account}&output=json",
+        "uri_pretty" : "https://archive.org/search.php?query={account}",
         "e_code" : 200,
-        "e_string" : "<!--/.item-ia-->",
-        "m_string" : "",
+        "e_string" : "backup_location",
+        "m_string" : "numFound\":0",
         "m_code" : 200,
         "known" : ["test", "mubix"],
         "cat" : "misc"


### PR DESCRIPTION
Using Internet Archive advanced search for the json output to fix the 302 redirection with the normal search
e_string and m_string updated
uri_pretty added