### PR TITLE
Fix Instagram check

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -2677,7 +2677,7 @@
         "uri_pretty" : "https://instagram.com/{account}",
         "uri_check" : "https://www.picuki.com/profile/{account}",
         "e_code" : 200,
-        "e_string" : "Instagram profile with posts and stories",
+        "e_string" : "Instagram public profile with posts",
         "m_string" : "Nothing found!",
         "m_code" : 404,
         "known" : ["katyperry", "kirbstr"],


### PR DESCRIPTION
Noted false negatives for **Instagram** searches. This issue arises because **Picuki** changed the title format for user profiles.

From
`Instagram profile with posts and stories`
to
` Instagram public profile with posts`

Fixing this with this PR.