### PR TITLE
Update wmn-data.json - removing friendweb

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1928,16 +1928,6 @@
         "cat" : "dating"
        },
        {
-        "name" : "Friendweb",
-        "uri_check" : "https://friendweb.nl/{account}",
-        "e_code" : 200,
-        "e_string" : "friendweb.nl",
-        "m_string" : "Page Not Found",
-        "m_code" : 404,
-        "known" : ["HoogtePiet", "JeePee"],
-        "cat" : "social"
-       },
-       {
         "name" : "FurAffinity",
         "uri_check" : "https://www.furaffinity.net/user/{account}",
         "e_code" : 200,


### PR DESCRIPTION
Since friendweb does not allow public viewing of profiles anymore, there is no good way to provide a check if the profile exists. This will give a lot of false positives. Therefor it should be removed.