### PR TITLE
Discogs, Virustotal and Wetransfer fix

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -5942,11 +5942,18 @@
       },
       {
         "name" : "Virustotal",
-        "uri_check" : "https://www.virustotal.com/gui/user/{account}",
+        "uri_check" : "https://www.virustotal.com/ui/users/{account}",
+        "pretty_uri" : "https://www.virustotal.com/gui/user/{account}",
+        "headers" : {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+                "X-Tool": "vt-ui-main",
+                "Accept-Ianguage": "en-US,en;q=0.9,es;q=0.8",
+                "X-VT-Anti-Abuse-Header": "MTAxOTFwMDcxOTEtWkc5dWRDQmlaU0JsZG2scy5xNzE4Mjc1NDI0LjUzMw=="
+        },
         "e_code" : 200,
-        "e_string" :"USER PROFILE",
-        "m_string" : "User not found",
-        "m_code" : 200,
+        "e_string" :"data",
+        "m_string" : "NotFoundError",
+        "m_code" : 404,
         "known" : ["cyber", "cybersecstu"],
         "cat" : "misc"
        },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1378,7 +1378,7 @@
         "known" : ["JeffG1", "Maxatoria"],
         "cat" : "social"
        },
-      {
+       {
         "name" : "Discogs",
         "uri_check" : "https://api.discogs.com/users/{account}",
         "pretty_uri" : "https://www.discogs.com/user/{account}",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -6111,9 +6111,9 @@
         "uri_check" : "https://{account}.wetransfer.com",
         "strip_bad_char" : ".",
         "e_code" : 200,
-        "e_string" : "default_recipient_email",
+        "e_string" : "workspaceName",
         "m_string" : "",
-        "m_code" : 302,
+        "m_code" : 307,
         "known" : ["mark", "joe"],
         "cat" : "misc"
        },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1378,14 +1378,15 @@
         "known" : ["JeffG1", "Maxatoria"],
         "cat" : "social"
        },
-       {
+      {
         "name" : "Discogs",
-        "uri_check" : "https://www.discogs.com/user/{account}",
+        "uri_check" : "https://api.discogs.com/users/{account}",
+        "pretty_uri" : "https://www.discogs.com/user/{account}",
         "e_code" : 200,
-        "e_string" : "Joined on",
+        "e_string" : "\"id\"",
         "m_code" : 404,
-        "m_string" : "We couldn't find that page.",
-        "known" : ["7jlong", "venetian-guy"],
+        "m_string" : "User does not exist",
+        "known" : ["damiano84", "bernadette69"],
         "cat" : "music"
        },
        {


### PR DESCRIPTION
**VirusTotal**

- Uses an undocumented endpoint to circumvent the profile page javascript loader.
- Headers are required, values can be dummy data, even for "X-VT-Anti-Abuse-Header" (works as well with "1"). But near expected values is more stealth.
- The I (maj "i") in the key "Accept-Ianguage" is on purpose, planted by VirusTotal.

**Discogs**

- Uses discogs official api to circumvent the page javascript loader.
- Official api rate limit is 25 requests per minute for unregistered user (by IP). It should be ok.
- Changed known accounts because they were not working (usernames changed by user)

**Wetransfer**

- e_string and m_code changed