### PR TITLE
Update wmn-data.json

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -2177,8 +2177,8 @@
        },
        {
         "name" : "Gravatar",
-        "uri_check" : "http://en.gravatar.com/{account}.json",
-        "uri_pretty" : "http://en.gravatar.com/{account}",
+        "uri_check" : "https://en.gravatar.com/{account}.json",
+        "uri_pretty" : "https://en.gravatar.com/{account}",
         "e_code" : 200,
         "e_string" : "entry",
         "m_string" : "User not found",


### PR DESCRIPTION
Gravatar redirects all requests from http to https returning a 301 status code on both existing and non-existing usernames