### PR TITLE
Added to wmn-data.json with SimplePlanes

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -4869,6 +4869,14 @@
         "cat" : "images"
        },
        {
+        "name" : "SimplePlanes",
+        "uri_check" : "https://www.simpleplanes.com/u/{account}",
+        "e_code" : 200,
+        "m_code" : 302,
+        "known" : ["realSavageMan", "Jundroo", "john"],
+        "cat" : "gaming"
+       },
+       {
         "name" : "skeb",
         "uri_check" : "https://skeb.jp/@{account}",
         "e_code" : 200,

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -4872,7 +4872,9 @@
         "name" : "SimplePlanes",
         "uri_check" : "https://www.simpleplanes.com/u/{account}",
         "e_code" : 200,
+        "e_string" : "<h5>joined"
         "m_code" : 302,
+        "m_string" : "<title>SimplePlanes Airplanes</title>"
         "known" : ["realSavageMan", "Jundroo", "john"],
         "cat" : "gaming"
        },


### PR DESCRIPTION
Added entry for SimplePlanes.com
{
        "name" : "SimplePlanes",
        "uri_check" : "https://www.simpleplanes.com/u/{account}",
        "e_code" : 200,
        "m_code" : 302,
        "known" : ["realSavageMan", "Jundroo", "john"],
        "cat" : "gaming"
       },
       Entry is missing its e_string and m_string as I do not yet know how to discern those