### PR TITLE
Correcting JSON error in Simple Planes entry

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -4882,9 +4882,9 @@
         "name" : "SimplePlanes",
         "uri_check" : "https://www.simpleplanes.com/u/{account}",
         "e_code" : 200,
-        "e_string" : "<h5>joined"
+        "e_string" : "<h5>joined",
         "m_code" : 302,
-        "m_string" : "<title>SimplePlanes Airplanes</title>"
+        "m_string" : "<title>SimplePlanes Airplanes</title>",
         "known" : ["realSavageMan", "Jundroo", "john"],
         "cat" : "gaming"
        },


### PR DESCRIPTION
# Issue
When attempting to use the site, the following can be found in the console:
> There was a problem with the fetch operation: SyntaxError: JSON.parse: expected ',' or '}' after property value in object at line 4886 column 9 of the JSON data

This is because the JSON object for **SimplePlanes** is missing some commas and therefore is not valid JSON.

# Fix
Adding commas to lines _4885_, and _4887_ return valid JSON when tested with a tool like [JSON Parser](http://json.parser.online.fr/) Online.