### PR TITLE
Adding Bluesky for default handles as Bluesky 2

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -668,7 +668,7 @@
         "cat" : "blog"
        },
        {
-        "name" : "Blue Sky",
+        "name" : "Bluesky 1",
         "uri_check" : "https://bsky.app/profile/{account}",
         "e_code" : 200,
         "e_string" : "on Bluesky",
@@ -676,6 +676,16 @@
         "m_string" : "<p id=\"bsky_did\"></p>",
         "known" : ["bsky.app", "safety.bsky.app"],
         "cat" : "social"
+       },
+       {
+         "name": "Bluesky 2",
+         "uri_check": "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={account}.bsky.social",
+         "e_code": 200,
+         "e_string": "\"handle\":\"",
+         "m_code": 400,
+         "m_string": "\"message\":\"Profile not found\"",
+         "known": ["john", "mark"],
+         "cat": "social"
        },
        {
         "name" : "BodyBuilding.com",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -680,6 +680,7 @@
        {
          "name": "Bluesky 2",
          "uri_check": "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={account}.bsky.social",
+         "uri_pretty" : "https://bsky.app/profile/{account}.bsky.social",
          "e_code": 200,
          "e_string": "\"handle\":\"",
          "m_code": 400,


### PR DESCRIPTION
Existing "Blue Sky" checks the full handle (with the domain). Useful to find someone from the full handle or from a personal domain as a handle. But it can't find a username in a default handle like username.bsky.social.

- "Blue Sky" renamed to "Bluesky 1"
- New "Bluesky 2" using the bluesky public API. It checks the username part in the default handle {{username}}.bsky.social, allowing to find "mark.bsky.social" from "mark".
Bluesky public API is cached and the rate limit is very high.