### PR TITLE
Fix for bblog_ru

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -488,10 +488,10 @@
         "name" : "bblog_ru",
         "uri_check" : "https://www.babyblog.ru/user/{account}",
         "e_code" : 200,
-        "e_string" : "@",
-        "m_string" : "БэбиБлог - беременность, календарь беременности, дневники",
+        "e_string" : ") — дневник на Babyblog.ru</title>",
+        "m_string" : "<title>БэбиБлог - беременность, календарь беременности, дневники</title>",
         "m_code" : 301,
-        "known" : ["igor", "olga"],
+        "known" : ["joyfitnessdance1", "bobkokatya94"],
         "cat" : "misc"
        },
        {


### PR DESCRIPTION
## Fix for `bblog_ru`

---

### False Positive 

Used WhatsMyName.app this morning and `bblog_ru` came out in the results for the user `gargron`, but no user exists.
Improved detection with e string change and m string changes.
I tested this with 2 python scripts, detection is now accurate.


