### PR TITLE
Add alternative for Medium handle

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -5257,7 +5257,7 @@
     },
     {
       "name": "Medium",
-      "uri_check": "https://medium.com/@{account}",
+      "uri_check": "https://medium.com/@{account}/about",
       "strip_bad_char": ".",
       "e_code": 200,
       "e_string": "Medium member since",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -5270,6 +5270,20 @@
       "cat": "news"
     },
     {
+      "name": "Medium handle",
+      "uri_check": "https://medium.com/@{account}",
+      "strip_bad_char": ".",
+      "e_code": 200,
+      "e_string": "Medium member since",
+      "m_string": "Out of nothing, something",
+      "m_code": 404,
+      "known": [
+        "zulie",
+        "jessicalexicus"
+      ],
+      "cat": "news"
+    },
+    {
       "name": "medyczka.pl",
       "uri_check": "http://medyczka.pl/user/{account}",
       "e_code": 200,

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -5257,20 +5257,6 @@
     },
     {
       "name": "Medium",
-      "uri_check": "https://{account}.medium.com/about",
-      "strip_bad_char": ".",
-      "e_code": 200,
-      "e_string": "Medium member since",
-      "m_string": "Out of nothing, something",
-      "m_code": 404,
-      "known": [
-        "zulie",
-        "jessicalexicus"
-      ],
-      "cat": "news"
-    },
-    {
-      "name": "Medium handle",
       "uri_check": "https://medium.com/@{account}",
       "strip_bad_char": ".",
       "e_code": 200,


### PR DESCRIPTION
Hi @WebBreacher

At this moment Medium.com is presented as `"uri_check": "https://{account}.medium.com/about",`, but there is alternative, like:
`"uri_check": "https://medium.com/@{account}",` - added.

Please feel free to let me know, if some part should be changed or fixed.

Best wishes,