### PR TITLE
Add NameSeeker Project to Tools List

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For a site to be included in WMN it has to:
 * [WhatsMyName-Client](https://github.com/grabowskiadrian/WhatsMyName-Client) a simple Python script with 'request headers' and 'POST requests' support made by [@grabowskiadrian](https://github.com/grabowskiadrian). The script also allows you to test the configuration of the wmn-data.json file.
 * [WhatsMyName-Web](https://github.com/AXRoux/WhatsMyName-Web) **Whats My Name-Web** is a simple Flask web app iteration of WhatsMyName made by [@AXRoux](https://github.com/AXRoux/)
 * [WhatsMyName Docker](https://github.com/kodamaChameleon/wmn-docker) is a Docker API Wrapper over this WhatsMyName tool. Dockerization made by [@kodamaChameleon](https://github.com/kodamaChameleon)
+* [NameSeeker](https://github.com/funnyzak/name-seeker) is a powerful cross-platform desktop application that searches for usernames and email addresses across hundreds of websites, helping you quickly discover your digital footprint. Based on the WhatsMyName project data, it supports exporting search results in PDF, CSV, JSON, and other formats.
 
 ## Content
 


### PR DESCRIPTION
Hi, I created a cross-platform desktop application called NameSeeker and would like to add it to the "Tools/Web Sites Using WhatsMyName" section.

## Project Information

- **Project Name**: NameSeeker
- **GitHub Repository**: https://github.com/funnyzak/name-seeker
- **Project Type**: Cross-platform desktop application
- **Tech Stack**: React + TypeScript + Tauri

## Project Description

NameSeeker is a powerful cross-platform desktop application that searches for usernames and email addresses across hundreds of websites, helping users quickly discover their digital footprint. The application is based on WhatsMyName project data and supports multiple export formats (PDF, CSV, JSON, etc.).

## Key Features

- Search usernames and email addresses across 600+ websites
- Real-time progress display
- Multiple export format support
- Smart filtering and sorting options
- Search history records
- Local processing for privacy protection
- Multi-language support (Chinese/English)
- Cross-platform support (Windows, macOS, Linux)