### PR TITLE
Remove misleading uri_pretty on Fanslist entry (resolves #1010).

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -2588,7 +2588,6 @@
     {
       "name": "Fanslist (OnlyFans)",
       "uri_check": "https://fanslist.com/search?q={account}",
-      "uri_pretty": "https://onlyfans.com/{account}",
       "e_code": 200,
       "e_string": "data-username=",
       "m_string": "No results found for query",


### PR DESCRIPTION
Addresses #1010 using Approach 4 as discussed in the Issue thread by removing the `uri_pretty` field from the Fanslist (OnlyFans) entry in `wmn-data.json` so hits (including partial or substring matches) are presented as Fanslist aggregator URLs instead of implied OnlyFans profile URLs. Doing so more accurately represents what the check actually verifies (a substring match on Fanslist's index) rather than implying an OnlyFans account exists that may not actually be there; this is especially important since prior to removal of `uri_pretty`, downstream consumers may have seen the data presented in a way that more strongly implied account ownership. Since `uri_check` is already a human-readable search results page, consumers will instead fall back to displaying it directly now that `uri_pretty` is absent.
However, if you prefer, I'm happy to switch to explicit duplication of `uri_check` or work on any other approach discussed (or new ideas).

It occurred to me that now that the entry no longer points at OnlyFans, the "(OnlyFans)" in the entry name is arguably misleading as well. I didn't want to scope-creep, but of course I'd be happy to submit a rename PR separately if you think it's warranted. 

Closes #1010
