### PR TITLE
Update wmn-data.json

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -9953,7 +9953,7 @@
     },
     {
       "name": "tripadvisor australia",
-      "uri_check": "https://tripadvisor.com.au/Profile/{username}",
+      "uri_check": "https://tripadvisor.com.au/Profile/{account}",
       "e_code": 200,
       "e_string": "Recent Achievements",
       "m_code": 404,
@@ -9965,7 +9965,7 @@
     },
     {
       "name": "tripadvisor",
-      "uri_check": "https://tripadvisor.com/Profile/{username}",
+      "uri_check": "https://tripadvisor.com/Profile/{account}",
       "e_code": 200,
       "e_sring": "Recent Achievements",
       "m_code": 404,

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -12,7 +12,7 @@
     "funnyzak",
     "mbiesiad",
     "Micah Hoffman",
-    "Owen Ross @Dev2023-Op",
+    "Owen Ross",
     "mtedholm"
   ],
   "categories": [
@@ -330,6 +330,21 @@
         "varunkumarb0001"
       ],
       "cat": "tech"
+    },
+    {
+      "name": "Arch Linux GitLab",
+      "uri_check": "https://gitlab.archlinux.org/api/v4/users?username={account}",
+      "uri_pretty": "https://gitlab.archlinux.org/{account}",
+      "protection": [ "anubis" ],
+      "e_code": 200,
+      "e_string": "\"id\":",
+      "m_string": "[]",
+      "m_code": 200,
+      "known": [
+        "morganamilo",
+        "nl6720"
+      ],
+      "cat": "social"
     },
     {
       "name": "Arduino (Forum)",
@@ -8550,7 +8565,7 @@
       "uri_check": "https://www.tripadvisor.com/Profile/{account}",
       "e_code": 200,
       "e_string": "Contributions",
-      "m_string": "This page is on vacation",
+      "m_string": "<div class=\"error404",
       "m_code": 404,
       "known": [
         "john",
@@ -9950,30 +9965,6 @@
         "Alinka1313"
       ],
       "cat": "social"
-    },
-    {
-      "name": "tripadvisor australia",
-      "uri_check": "https://tripadvisor.com.au/Profile/{account}",
-      "e_code": 200,
-      "e_string": "Recent Achievements",
-      "m_code": 404,
-      "m_string": "This page is on holiday",
-      "known": [
-        "amiresteki"
-      ],
-      "cat": "misc"
-    },
-    {
-      "name": "tripadvisor",
-      "uri_check": "https://tripadvisor.com/Profile/{account}",
-      "e_code": 200,
-      "e_sring": "Recent Achievements",
-      "m_code": 404,
-      "m_string": "This page is on holiday",
-      "known": [
-        "amiresteki"
-      ],
-      "cat": "misc"
     }
   ]
 }

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -12,6 +12,7 @@
     "funnyzak",
     "mbiesiad",
     "Micah Hoffman",
+    "Owen Ross @Dev2023-Op"
     "mtedholm"
   ],
   "categories": [
@@ -9968,25 +9969,52 @@
       "name": "tryhackme",
       "uri_check": "https://tryhackme.com/p/{account}",
       "e_code": 200,
+      "e_string": "Rank",
+      "m_code": 404,
       "m_string": "Page not found",
       "headers" : {
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
       },
-      "cat": "hacking"
-    }
+      "known": [
+        "oross21"
+      ]
+      "cat": "tech"
+    },
     {
       "name": "chess.com",
       "uri_check": "https://chess.com/member/{username}",
       "e_code": 200,
+      "e_string": "Game History";
+      "m_code": 404,
       "m_string": "404 Page not found",
-      "cat": "games"
-    }
+      "known": [
+        "oross21"
+      ],
+      "cat": "gaming"
+    },
     {
-      "name": "tripadvisor.com",
+      "name": "tripadvisor australia",
       "uri_check": "https://tripadvisor.com.au/Profile/{username}",
       "e_code": 200,
+      "e_string": "Recent Achievements",
+      "m_code": 404,
       "m_string": "This page is on holiday",
-      "cat": "travel"
+      "known": [
+        "amiresteki"
+      ],
+      "cat": "misc"
+    },
+    {
+      "name": "tripadvisor",
+      "uri_check": "https://tripadvisor.com/Profile/{username}",
+      "e_code": 200,
+      "e_sring": "Recent Achievements",
+      "m_code": 404,
+      "m_string": "This page is on holiday",
+      "known": [
+        "amiresteki"
+      ],
+      "cat": "misc"
     }
   ]
 }

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -346,7 +346,7 @@
       "cat": "social"
       "protection": [ 
         "anubis" 
-      ],
+      ]
     },
     {
       "name": "Arduino (Forum)",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -341,11 +341,11 @@
       "m_code": 200,
       "known": [
         "morganamilo",
-        "nl6720",
+        "nl6720"
       ],
       "cat": "social",
-      "protection": [ 
-        "anubis" 
+      "protection": [
+        "anubis"
       ]
     },
     {

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -12,7 +12,7 @@
     "funnyzak",
     "mbiesiad",
     "Micah Hoffman",
-    "Owen Ross @Dev2023-Op"
+    "Owen Ross @Dev2023-Op",
     "mtedholm"
   ],
   "categories": [

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -335,7 +335,6 @@
       "name": "Arch Linux GitLab",
       "uri_check": "https://gitlab.archlinux.org/api/v4/users?username={account}",
       "uri_pretty": "https://gitlab.archlinux.org/{account}",
-      "protection": [ "anubis" ],
       "e_code": 200,
       "e_string": "\"id\":",
       "m_string": "[]",
@@ -345,6 +344,9 @@
         "nl6720"
       ],
       "cat": "social"
+      "protection": [ 
+        "anubis" 
+      ],
     },
     {
       "name": "Arduino (Forum)",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -332,20 +332,6 @@
       "cat": "tech"
     },
     {
-      "name": "Arch Linux GitLab",
-      "uri_check": "https://gitlab.archlinux.org/api/v4/users?username={account}",
-      "uri_pretty": "https://gitlab.archlinux.org/{account}",
-      "e_code": 200,
-      "e_string": "\"id\":",
-      "m_string": "[]",
-      "m_code": 200,
-      "known": [
-        "morganamilo",
-        "nl6720"
-      ],
-      "cat": "social"
-    },
-    {
       "name": "Arduino (Forum)",
       "uri_check": "https://forum.arduino.cc/u/{account}.json",
       "uri_pretty": "https://forum.arduino.cc/u/{account}/summary",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -343,7 +343,7 @@
         "morganamilo",
         "nl6720",
       ],
-      "cat": "social"
+      "cat": "social",
       "protection": [ 
         "anubis" 
       ]

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -9964,5 +9964,29 @@
       ],
       "cat": "social"
     }
+    {
+      "name": "tryhackme",
+      "uri_check": "https://tryhackme.com/p/{account}",
+      "e_code": 200,
+      "m_string": "Page not found",
+      "headers" : {
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+      },
+      "cat": "hacking"
+    }
+    {
+      "name": "chess.com",
+      "uri_check": "https://chess.com/member/{username}",
+      "e_code": 200,
+      "m_string": "404 Page not found",
+      "cat": "games"
+    }
+    {
+      "name": "tripadvisor.com",
+      "uri_check": "https://tripadvisor.com.au/Profile/{username}",
+      "e_code": 200,
+      "m_string": "This page is on holiday",
+      "cat": "travel"
+    }
   ]
 }

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -341,7 +341,7 @@
       "m_code": 200,
       "known": [
         "morganamilo",
-        "nl6720"
+        "nl6720",
       ],
       "cat": "social"
       "protection": [ 

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -9950,33 +9950,6 @@
         "Alinka1313"
       ],
       "cat": "social"
-    }
-    {
-      "name": "tryhackme",
-      "uri_check": "https://tryhackme.com/p/{account}",
-      "e_code": 200,
-      "e_string": "Rank",
-      "m_code": 404,
-      "m_string": "Page not found",
-      "headers" : {
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
-      },
-      "known": [
-        "oross21"
-      ]
-      "cat": "tech"
-    },
-    {
-      "name": "chess.com",
-      "uri_check": "https://chess.com/member/{username}",
-      "e_code": 200,
-      "e_string": "Game History";
-      "m_code": 404,
-      "m_string": "404 Page not found",
-      "known": [
-        "oross21"
-      ],
-      "cat": "gaming"
     },
     {
       "name": "tripadvisor australia",


### PR DESCRIPTION
## Type of change

- [x] New site added to `wmn-data.json`
- [x] Fix to an existing site entry (broken detection, updated URL, etc.)
- [ ] Other (docs, scripts, etc.)

## Checklist (for new or updated site entries)

- [x] I tested `uri_check` against a real, existing account and confirmed `e_code`/`e_string` match
- [x] I tested `uri_check` against a non-existent username and confirmed `m_code`/`m_string` match
- [x] `e_string`/`m_string` are specific enough to avoid false positives/negatives (not too generic, not username-specific)
- [x] The site is publicly accessible (no login/paywall) and the username appears directly in the profile URL
- [x] My JSON is valid (the file will be auto-formatted/sorted and schema-validated by GitHub Actions)

## Description

<!-- What does this PR change, and why? -->
adds detection for Trip advisor Australia and global accounts.
removed the arch linux gitlab link as they have added protection