### PR TITLE
wmn-data: add new sites (split from #1051, 4 of 4)

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -633,7 +633,7 @@
       "name": "Behance",
       "uri_check": "https://www.behance.net/{account}",
       "e_code": 200,
-      "e_string": "\"entityOwners\":[{",
+      "e_string": "\"entityOwners\":[{\"username",
       "m_string": "\"entityOwners\":[]",
       "m_code": 404,
       "known": [
@@ -1607,7 +1607,7 @@
     {
       "name": "Dailymotion",
       "uri_check": "https://api.dailymotion.com/user/{account}?fields=id,username,screenname,description,avatar_720_url,cover_250_url,followers_total,following_total,videos_total,country,created_time,verified,url",
-      "uri_pretty": "https://www.dailymotion.com/{account}",
+      "uri_pretty": "https://www.dailymotion.com/user/{account}",
       "e_code": 200,
       "e_string": "\"id\":",
       "m_string": "\"code\":404",
@@ -7866,8 +7866,8 @@
       "m_string": "\"status\":404",
       "m_code": 404,
       "known": [
-        "boskiseksowny",
-        "matsuoshi"
+        "korel",
+        "linnealawder"
       ],
       "cat": "music"
     },

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -298,6 +298,20 @@
       ]
     },
     {
+      "name": "Aparat",
+      "uri_check": "https://www.aparat.com/api/fa/v1/user/user/information/username/{account}",
+      "uri_pretty": "https://www.aparat.com/{account}",
+      "e_code": 200,
+      "e_string": "\"data\":{",
+      "m_string": "\"status\":404",
+      "m_code": 404,
+      "known": [
+        "unni_gilda",
+        "Dokhmal1389"
+      ],
+      "cat": "video"
+    },
+    {
       "name": "Apex Legends",
       "uri_check": "https://api.tracker.gg/api/v2/apex/standard/profile/origin/{account}",
       "uri_pretty": "https://apex.tracker.gg/apex/profile/origin/{account}/overview",
@@ -614,6 +628,19 @@
       "protection": [
         "cloudflare"
       ]
+    },
+    {
+      "name": "Behance",
+      "uri_check": "https://www.behance.net/{account}",
+      "e_code": 200,
+      "e_string": "\"entityOwners\":[{",
+      "m_string": "\"entityOwners\":[]",
+      "m_code": 404,
+      "known": [
+        "mangarawma",
+        "atelieravocado"
+      ],
+      "cat": "business"
     },
     {
       "name": "Bentbox",
@@ -1578,6 +1605,20 @@
       "cat": "news"
     },
     {
+      "name": "Dailymotion",
+      "uri_check": "https://api.dailymotion.com/user/{account}?fields=id,username,screenname,description,avatar_720_url,cover_250_url,followers_total,following_total,videos_total,country,created_time,verified,url",
+      "uri_pretty": "https://www.dailymotion.com/{account}",
+      "e_code": 200,
+      "e_string": "\"id\":",
+      "m_string": "\"code\":404",
+      "m_code": 404,
+      "known": [
+        "chinesedramastudio",
+        "franceinter"
+      ],
+      "cat": "video"
+    },
+    {
       "name": "darudar",
       "uri_check": "https://darudar.org/users/{account}/",
       "e_code": 200,
@@ -2003,6 +2044,19 @@
       "known": [
         "gorou",
         "saku"
+      ],
+      "cat": "finance"
+    },
+    {
+      "name": "DonationPay",
+      "uri_check": "https://give.donationpay.org/hopewell-fund/{account}/",
+      "e_code": 200,
+      "e_string": "id=\"dp-payment-form\"",
+      "m_string": "<title>404 Not Found</title>",
+      "m_code": 404,
+      "known": [
+        "rareimpact",
+        "leadershipnow"
       ],
       "cat": "finance"
     },
@@ -4676,6 +4730,20 @@
       "cat": "tech"
     },
     {
+      "name": "LiveJasmin",
+      "uri_check": "https://www.livejasmin.com/en/flash/get-performer-details/{account}",
+      "uri_pretty": "https://www.livejasmin.com/en/chat/{account}",
+      "e_code": 200,
+      "e_string": "\"success\":true",
+      "m_string": "\"success\":false",
+      "m_code": 200,
+      "known": [
+        "NaiaCollins",
+        "LoraClay"
+      ],
+      "cat": "xx NSFW xx"
+    },
+    {
       "name": "Livejournal",
       "uri_check": "https://{account}.livejournal.com",
       "strip_bad_char": ".",
@@ -4780,6 +4848,20 @@
         "johnebaker"
       ],
       "cat": "music"
+    },
+    {
+      "name": "Magnific",
+      "uri_check": "https://www.magnific.com/app/api/community/creator-info-by-name?creator_name={account}&lang=en_US",
+      "uri_pretty": "https://www.magnific.com/app/creator/{account}",
+      "e_code": 200,
+      "e_string": "\"creator\":",
+      "m_string": "\"message\":\"Creator not found\"",
+      "m_code": 404,
+      "known": [
+        "membiz",
+        "LaraRed"
+      ],
+      "cat": "art"
     },
     {
       "name": "Malpedia Actors",
@@ -6020,6 +6102,23 @@
       "cat": "social"
     },
     {
+      "name": "Paragraph",
+      "uri_check": "https://paragraph.com/api/blogs/@{account}",
+      "uri_pretty": "https://paragraph.com/@{account}",
+      "headers": {
+        "Accept": "application/json"
+      },
+      "e_code": 200,
+      "e_string": "\"user\":{",
+      "m_string": "\"Missing blog\"",
+      "m_code": 404,
+      "known": [
+        "wibtal",
+        "developerdao"
+      ],
+      "cat": "blog"
+    },
+    {
       "name": "Parler",
       "uri_check": "https://parler.com/user/{account}",
       "e_code": 200,
@@ -6399,6 +6498,19 @@
         "john"
       ],
       "cat": "social"
+    },
+    {
+      "name": "Planoly",
+      "uri_check": "https://planoly.store/{account}",
+      "e_code": 200,
+      "e_string": "\"creatorLink\":{",
+      "m_string": "\"statusCode\":404",
+      "m_code": 404,
+      "known": [
+        "divinemystique",
+        "brujasesoterica"
+      ],
+      "cat": "misc"
     },
     {
       "name": "Playstation Network",
@@ -7744,6 +7856,20 @@
       "protection": [
         "other"
       ]
+    },
+    {
+      "name": "stats.fm",
+      "uri_check": "https://api.stats.fm/api/v1/users/{account}",
+      "uri_pretty": "https://stats.fm/{account}",
+      "e_code": 200,
+      "e_string": "\"item\":{",
+      "m_string": "\"status\":404",
+      "m_code": 404,
+      "known": [
+        "boskiseksowny",
+        "matsuoshi"
+      ],
+      "cat": "music"
     },
     {
       "name": "Statuspage",


### PR DESCRIPTION
Split from #1051 into smaller batches for review. This is batch 4 of 4: new site additions.

## New sites (9)
Aparat, Behance, Dailymotion, DonationPay, LiveJasmin, Magnific, Paragraph, Planoly, stats.fm

Roberts Space Industries was originally part of this batch but was dropped after rebasing: it was independently added directly to main with different, already-verified detection logic (different uri_check endpoint, e_string, and known accounts than the original PR proposal). Keeping the already-verified version rather than overwriting it with the older one from #1051.

Pure additions, no changes to any existing entries.

Before merging: verify uri_check against both a real and a non-existent account for each new site, per the existing PR checklist.

Original author: 3xp0rt (from #1051)