### PR TITLE
wmn-data: fix header for virustotal

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -8895,7 +8895,7 @@
       "uri_check": "https://www.virustotal.com/ui/users/{account}",
       "uri_pretty": "https://www.virustotal.com/gui/user/{account}",
       "headers": {
-        "Accept-Ianguage": "en-US",
+        "Accept-Language": "en-US",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
         "X-Tool": "vt-ui-main",
         "X-VT-Anti-Abuse-Header": "MTAxOTFwMDcxOTEtWkc5dWRDQmlaU0JsZG2scy5xNzE4Mjc1NDI0LjUzMw=="


### PR DESCRIPTION
## Type of change

- [ ] New site added to `wmn-data.json`
- [x] Fix to an existing site entry (broken detection, updated URL, etc.)
- [ ] Other (docs, scripts, etc.)

## Checklist (for new or updated site entries)

- [x] I tested `uri_check` against a real, existing account and confirmed `e_code`/`e_string` match
- [x] I tested `uri_check` against a non-existent username and confirmed `m_code`/`m_string` match
- [x] `e_string`/`m_string` are specific enough to avoid false positives/negatives (not too generic, not username-specific)
- [x] The site is publicly accessible (no login/paywall) and the username appears directly in the profile URL
- [x] My JSON is valid (the file will be auto-formatted/sorted and schema-validated by GitHub Actions)

## Description

Fixed typo in the `Accept-Language` header 