### PR TITLE
fix(scripts): report JSON syntax errors cleanly in validate_json.py

### DIFF
--- a/scripts/validate_json.py
+++ b/scripts/validate_json.py
@@ -7,12 +7,18 @@ DATA_FILE = "wmn-data.json"
 SCHEMA_FILE = "wmn-data-schema.json"
 
 
-def main():
-    with open(DATA_FILE, encoding="utf-8") as f:
-        data = json.load(f)
+def load_json(path):
+    with open(path, encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"ERROR: {path} is not valid JSON: {e.msg} at line {e.lineno} column {e.colno}")
+            sys.exit(1)
 
-    with open(SCHEMA_FILE, encoding="utf-8") as f:
-        schema = json.load(f)
+
+def main():
+    data = load_json(DATA_FILE)
+    schema = load_json(SCHEMA_FILE)
 
     validator = Draft7Validator(schema)
     errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))


### PR DESCRIPTION
validate_json.py calls json.load() with no error handling around it. If wmn-data.json has a JSON syntax error (extra comma, unbalanced brace, etc.) rather than a schema violation, the script crashes with an unhandled Python traceback in the Actions log instead of printing a clean message.

The line and column number were technically present in the traceback, just buried at the bottom of 15+ lines of stack trace, easy to miss when scanning CI output.

This wraps both file loads in a helper that catches json.JSONDecodeError and prints a one-line message in the same style as the existing schema-error output:

    ERROR: wmn-data.json is not valid JSON: Expecting property name enclosed in double quotes at line 345 column 9

Reproduced locally with a wmn-data.json containing a stray trailing comma, before and after the fix, and confirmed valid JSON still passes cleanly.

Type of change:
- [x] Other (docs, scripts, etc.)