### PR TITLE
docs: tell AI-assisted contributors to read CONTRIBUTING.md and schema first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,12 @@ If you get stuck here, an issue with your example profile link is a perfectly go
 
 ## Using AI tools
 
+If you're using an AI assistant for your work, make sure you start off right: have it read this page before it touches anything. Beyond this page, also point it at:
+
+- [`wmn-data-schema.json`](wmn-data-schema.json) -- the authoritative field types and required/optional fields, plus the full list of valid `cat` and `protection` values (this page only summarizes them)
+- A few existing entries in [`wmn-data.json`](wmn-data.json) in the same category as your site, so it matches real-world entries rather than just the illustrative examples above
+- [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md), if you're also having it draft your PR description
+
 Feel free to leverage the power and attention to detail of AI systems to format, verify, and validate your changes before submitting -- checking JSON validity, comparing your entry against the rules above, or double-checking `e_string`/`m_string` uniqueness. If you do, please keep any AI-generated commentary in the PR description brief; we want a couple of sentences on what changed and why, not a lengthy AI-authored writeup.
 
 ---


### PR DESCRIPTION
Follow-up to #1064. Expands the Using AI tools section to lead with the actual instruction rather than just permission: have the assistant read this page before it touches anything.

Also points it at what's above and beyond this page:
- wmn-data-schema.json, for the full cat/protection enums and exact field types (this page only summarizes them)
- a few real entries in wmn-data.json in the same category, so the AI matches real style rather than just the illustrative GET/POST examples
- .github/PULL_REQUEST_TEMPLATE.md, if it's drafting the PR description too

Kept the existing permission-to-use-AI and keep-commentary-brief paragraph as is.

Type of change:
- [x] Other (docs, scripts, etc.)