### PR TITLE
ci: add workflow to lock closed threads

### DIFF
--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -1,0 +1,28 @@
+name: 'Lock closed threads'
+
+on:
+  schedule:
+    # Runs daily. Adjust frequency once the initial backlog is processed.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v6
+        with:
+          github-token: ${{ github.token }}
+          # Lock PRs 3 days after they're closed. Adjust to taste.
+          pr-inactive-days: '3'
+          pr-lock-reason: 'resolved'
+          # Same for issues. Set to '' on either line to leave that type unlocked.
+          issue-inactive-days: '30'
+          issue-lock-reason: 'resolved'
+          # Don't touch threads that already have ongoing discussion tags.
+          exclude-any-issue-labels: 'help wanted, keep-open'
+          exclude-any-pr-labels: 'keep-open'


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Actions workflow (`dessant/lock-threads@v6`) that locks closed PRs after 3 days and closed issues after 30 days, to prevent comments/activity on stale closed threads.
- Runs daily via cron, plus supports manual trigger via `workflow_dispatch`.
- Threads labeled `keep-open` (issues also: `help wanted`) are excluded.

## Test plan
- [ ] Merge to `main` (schedule triggers only fire from the default branch)
- [ ] Manually trigger via `workflow_dispatch` in the Actions tab to confirm it runs cleanly before relying on the cron schedule
- [ ] Spot check that a handful of old closed PRs/issues get locked as expected