### PR TITLE
maint: copyright year, sample.json formatting, categories/cat sync check

### DIFF
--- a/.github/workflows/sort-format-json.yml
+++ b/.github/workflows/sort-format-json.yml
@@ -6,6 +6,9 @@ on:
       - 'wmn-data.json'
       - 'wmn-data-schema.json'
 
+permissions:
+  contents: write
+
 jobs:
   sort-and-format-json:
     name: Sort and Format JSON Files
@@ -27,5 +30,4 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           git add wmn-data.json wmn-data-schema.json
-          git diff --cached --quiet || git commit -m "chore: auto-sort and format JSON files"
-          git push
+          git diff --cached --quiet || (git commit -m "chore: auto-sort and format JSON files" && git push)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (C) Micah Hoffman
+Copyright (C) 2015-2026 Micah Hoffman
 
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative Commons,

--- a/sample.json
+++ b/sample.json
@@ -1,37 +1,65 @@
 {
   "_comment1": "Do not submit your changes in this sample.json file as it is only for testing!",
 
-  "categories" : ["archived","art","blog","business","coding","dating","finance","gaming","health",
-  "hobby","images","misc","music","news","political","search","shopping","social",
-  "tech","video","xx NSFW xx"],
+  "categories": [
+    "archived",
+    "art",
+    "blog",
+    "business",
+    "coding",
+    "dating",
+    "finance",
+    "gaming",
+    "health",
+    "hobby",
+    "images",
+    "misc",
+    "music",
+    "news",
+    "political",
+    "search",
+    "shopping",
+    "social",
+    "tech",
+    "video",
+    "xx NSFW xx"
+  ],
 
-  "sites" : [
+  "sites": [
     {
-      "name" : "Example GET",
-      "uri_check" : "https://www.example.com/load_profile_info.php?name={account}",
-      "uri_pretty" : "https://www.test.com/profile/{account}",
-      "e_code" : 200,
-      "e_string" : "regist_at",
-      "m_code" : 404,
-      "m_string" : "Account not found",
-      "known" : ["whoami", "johndoe"],
-      "cat" : "images"
+      "name": "Example GET",
+      "uri_check": "https://www.example.com/load_profile_info.php?name={account}",
+      "uri_pretty": "https://www.test.com/profile/{account}",
+      "e_code": 200,
+      "e_string": "regist_at",
+      "m_string": "Account not found",
+      "m_code": 404,
+      "known": [
+        "whoami",
+        "johndoe"
+      ],
+      "cat": "images"
     },
     {
-      "name" : "Example POST",
-      "uri_check" : "https://www.example.com/interact_api/load_profile_info.php",
-      "post_body" : "username={account}&csrf_token=abc123",
-      "strip_bad_char" : ".",
-      "e_code" : 200,
-      "e_string" : "regist_at",
-      "m_code" : 404,
-      "m_string" : "Account not found",
-      "known" : ["whoami", "johndoe"],
-      "cat" : "images",
-      "protection" : ["captcha"],
+      "name": "Example POST",
+      "uri_check": "https://www.example.com/interact_api/load_profile_info.php",
+      "post_body": "username={account}&csrf_token=abc123",
       "headers": {
-               "accept": "text/html"
-       }
+        "Accept": "text/html"
+      },
+      "strip_bad_char": ".",
+      "e_code": 200,
+      "e_string": "regist_at",
+      "m_string": "Account not found",
+      "m_code": 404,
+      "known": [
+        "whoami",
+        "johndoe"
+      ],
+      "cat": "images",
+      "protection": [
+        "captcha"
+      ]
     }
   ]
 }

--- a/scripts/validate_json.py
+++ b/scripts/validate_json.py
@@ -16,6 +16,29 @@ def load_json(path):
             sys.exit(1)
 
 
+def check_categories_match_cat_enum(data, schema):
+    categories = set(data.get("categories", []))
+    cat_enum = set(
+        schema.get("properties", {})
+        .get("sites", {})
+        .get("items", {})
+        .get("properties", {})
+        .get("cat", {})
+        .get("enum", [])
+    )
+    if categories == cat_enum:
+        return None
+
+    missing_from_enum = categories - cat_enum
+    missing_from_categories = cat_enum - categories
+    details = []
+    if missing_from_enum:
+        details.append(f"in categories but not in cat enum: {sorted(missing_from_enum)}")
+    if missing_from_categories:
+        details.append(f"in cat enum but not in categories: {sorted(missing_from_categories)}")
+    return "categories array and cat enum are out of sync (" + "; ".join(details) + ")"
+
+
 def main():
     data = load_json(DATA_FILE)
     schema = load_json(SCHEMA_FILE)
@@ -23,7 +46,9 @@ def main():
     validator = Draft7Validator(schema)
     errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
 
-    if not errors:
+    category_sync_error = check_categories_match_cat_enum(data, schema)
+
+    if not errors and not category_sync_error:
         print(f"{DATA_FILE} is valid against {SCHEMA_FILE}.")
         return 0
 
@@ -35,7 +60,11 @@ def main():
         location = f"sites[{path[1]}] ({site_name})" if site_name else "/".join(str(p) for p in path)
         print(f"ERROR at {location}: {error.message}")
 
-    print(f"\n{len(errors)} error(s) found in {DATA_FILE}.")
+    if category_sync_error:
+        print(f"ERROR: {category_sync_error}")
+
+    total_errors = len(errors) + (1 if category_sync_error else 0)
+    print(f"\n{total_errors} error(s) found in {DATA_FILE}.")
     return 1
 
 

--- a/wmn-data-schema.json
+++ b/wmn-data-schema.json
@@ -14,7 +14,7 @@
     "license": {
       "description": "CC BY-SA 4.0 license text",
       "const": [
-        "Copyright (C) Micah Hoffman",
+        "Copyright (C) 2015-2026 Micah Hoffman",
         "This work is licensed under the Creative Commons Attribution-ShareAlike",
         "4.0 International License. To view a copy of this license, visit",
         "http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -1,6 +1,6 @@
 {
   "license": [
-    "Copyright (C) Micah Hoffman",
+    "Copyright (C) 2015-2026 Micah Hoffman",
     "This work is licensed under the Creative Commons Attribution-ShareAlike",
     "4.0 International License. To view a copy of this license, visit",
     "http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to",


### PR DESCRIPTION
## Summary
- Update copyright year to 2015-2026 in LICENSE.md, wmn-data.json, and wmn-data-schema.json (kept in sync since the schema's `license` field is a `const`)
- Reformat sample.json to match wmn-data.json's real conventions: schema key order, one-array-item-per-line, capitalized header names (e.g. `Accept` not `accept`)
- validate_json.py: new check that fails validation if the top-level `categories` array and the schema's per-site `cat` enum drift out of sync (previously only matched by coincidence, nothing enforced it)

## Test plan
- [x] `python scripts/validate_json.py` passes
- [x] Manually verified the new categories/cat check fails on an intentionally mismatched test file