### PR TITLE
fix(ci): stop lock-closed-threads from erroring on disabled Discussions

### DIFF
--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -26,3 +26,6 @@ jobs:
           # Don't touch threads that already have ongoing discussion tags.
           exclude-any-issue-labels: 'help wanted, keep-open'
           exclude-any-pr-labels: 'keep-open'
+          # This repo doesn't have GitHub Discussions enabled; the action locks
+          # discussions by default and errors out if that feature is off.
+          process-only: 'issues, prs'


### PR DESCRIPTION
## Summary
- The daily "Lock closed threads" workflow has been failing on every scheduled run since it was added: `dessant/lock-threads@v6` locks issues, PRs, *and* discussions by default (`discussion-inactive-days` defaults to `365` even when not set in our workflow).
- This repo doesn't have GitHub Discussions enabled, so the action's discussion-locking step errors with `Resource not accessible by integration`, and that failure takes the whole run down — issues and PRs never got locked either.
- Fix: add `process-only: 'issues, prs'` to skip discussions entirely.

## Test plan
- [ ] Merge and manually trigger via `workflow_dispatch` to confirm a clean run