### PR TITLE
fix(ci): grant discussions write permission to lock-closed-threads

### DIFF
--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  discussions: write
 
 jobs:
   lock:


### PR DESCRIPTION
## Summary
- Discussions was re-enabled on the repo, but the "Lock closed threads" workflow still failed with `Resource not accessible by integration`.
- Root cause: the workflow's `permissions:` block only granted `issues: write` and `pull-requests: write` -- never `discussions: write`. The action's discussion-locking GraphQL calls need that scope regardless of whether the repo feature is on.
- Fix: add `discussions: write` to the permissions block.

## Test plan
- [x] Ran `workflow_dispatch` directly on this branch (`fix-lock-threads-discussions-permission`) -- completed successfully: https://github.com/WebBreacher/WhatsMyName/actions/runs/31980177273