### PR TITLE
Fix false positives

### DIFF
--- a/wmn-data.json
+++ b/wmn-data.json
@@ -350,8 +350,8 @@
       "uri_check": "https://gitlab.archlinux.org/api/v4/users?username={account}",
       "uri_pretty": "https://gitlab.archlinux.org/{account}",
       "e_code": 200,
-      "e_string": "\"id\":",
-      "m_string": "[]",
+      "e_string": "activity\" href=\"https://gitlab.archlinux.org/",
+      "m_string": "<div class=\"gl-grow\">Sign in before continuing.",
       "m_code": 200,
       "known": [
         "morganamilo",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -4141,8 +4141,8 @@
       "uri_check": "https://archive.org/advancedsearch.php?q=creator:{account}&output=json",
       "uri_pretty": "https://archive.org/search.php?query=creator:{account}",
       "e_code": 200,
-      "e_string": "backup_location",
-      "m_string": "numFound\":0",
+      "e_string": "<a aria-describedby=\"link-aria-description\" class=\"tile-link\" href=\"/details/",
+      "m_string": "<div class=\"search-empty-message\" slot=\"cb-results\">",
       "m_code": 200,
       "known": [
         "brewster_kahle",
@@ -4155,8 +4155,8 @@
       "uri_check": "https://archive.org/advancedsearch.php?q={account}&output=json",
       "uri_pretty": "https://archive.org/search.php?query={account}",
       "e_code": 200,
-      "e_string": "backup_location",
-      "m_string": "numFound\":0",
+      "e_string": "<a aria-describedby=\"link-aria-description\" class=\"tile-link\" href=\"/details/",
+      "m_string": "<div class=\"search-empty-message\" slot=\"cb-results\">",
       "m_code": 200,
       "known": [
         "anazgnos",

--- a/wmn-data.json
+++ b/wmn-data.json
@@ -8307,8 +8307,8 @@
       "name": "thegatewaypundit",
       "uri_check": "https://www.thegatewaypundit.com/author/{account}/",
       "e_code": 200,
-      "e_string": "summary",
-      "m_string": "Not found, error 404",
+      "e_string": "<meta property=\"og:type\" content=\"profile\" />",
+      "m_string": "ai_insert ('after', '.home-posts-list-grid', b64d",
       "m_code": 404,
       "known": [
         "patti",


### PR DESCRIPTION
## Type of change

- [ ] New site added to `wmn-data.json`
- [x] Fix to an existing site entry (broken detection, updated URL, etc.)
- [ ] Other (docs, scripts, etc.)

## Checklist (for new or updated site entries)

- [x] I tested `uri_check` against a real, existing account and confirmed `e_code`/`e_string` match
- [x] I tested `uri_check` against a non-existent username and confirmed `m_code`/`m_string` match
- [x] `e_string`/`m_string` are specific enough to avoid false positives/negatives (not too generic, not username-specific)
- [x] The site is publicly accessible (no login/paywall) and the username appears directly in the profile URL
- [x] My JSON is valid (the file will be auto-formatted/sorted and schema-validated by GitHub Actions)

## Description

<!-- What does this PR change, and why? -->

Fix false positives for internet archive, the gateway pundit and arch linux gitlab.

### arch linux

```
      "e_string": "\"id\":",
      "m_string": "[]",
```
to
```
      "e_string": "activity\" href=\"https://gitlab.archlinux.org/",
      "m_string": "<div class=\"gl-grow\">Sign in before continuing.",
```

### internet archive

```
      "e_string": "backup_location",
      "m_string": "numFound\":0",
```
to
```
      "e_string": "<a aria-describedby=\"link-aria-description\" class=\"tile-link\" href=\"/details/",
      "m_string": "<div class=\"search-empty-message\" slot=\"cb-results\">",
```

### The Gateway Pundit

```
      "e_string": "summary",
      "m_string": "Not found, error 404",
```
to
```
      "e_string": "<meta property=\"og:type\" content=\"profile\" />",
      "m_string": "ai_insert ('after', '.home-posts-list-grid', b64d",
```